### PR TITLE
Clarify `prof:isProfileOf` vs `owl:imports`

### DIFF
--- a/shacl-shacl/shsh12-core.ttl
+++ b/shacl-shacl/shsh12-core.ttl
@@ -1,1 +1,11 @@
-# SHACL 1.2 Core SHACL-SHACL validator
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>
+
+
+shsh:ShaclShaclCore
+    a owl:Ontology ;
+    rdfs:label "SHACL 1.2 Core SHACL-SHACL validator"@en ;
+    rdfs:comment "This shapes graph can be used to validate any SHACL 1.2 shapes graphs for core syntactic requirements specified by SHACL 1.2."@en ;
+.

--- a/shacl-shacl/shsh12-node-expr.ttl
+++ b/shacl-shacl/shsh12-node-expr.ttl
@@ -1,1 +1,14 @@
-# SHACL 1.2 Node Expressions SHACL-SHACL validator
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX prof: <http://www.w3.org/ns/dx/prof/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>
+
+
+shsh:ShaclShaclNodeExpressions
+    a owl:Ontology ;
+    owl:imports shsh:ShaclShaclCore ;
+    prof:isProfileOf shsh:ShaclShaclCore ;
+    rdfs:label "SHACL 1.2 Node Expressions SHACL-SHACL validator"@en ;
+    rdfs:comment "This shapes graph can be used to validate any SHACL 1.2 shapes graphs exercising Node Expression functionality."@en ;
+.

--- a/shacl-shacl/shsh12-union.ttl
+++ b/shacl-shacl/shsh12-union.ttl
@@ -7,6 +7,13 @@ PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>
 
 shsh:ShaclShaclUnion
     a owl:Ontology ;
+    owl:imports
+        shsh:ShaclShaclCompactSyntax ,
+        shsh:ShaclShaclInferenceRules ,
+        shsh:ShaclShaclNodeExpressions ,
+        shsh:ShaclShaclProfiling ,
+        shsh:ShaclShaclSparql ,
+        shsh:ShaclShaclUserInterface ;
     prof:isProfileOf
         shsh:ShaclShaclCore ,
         shsh:ShaclShaclCompactSyntax ,

--- a/shacl-shacl/shsh12-union.ttl
+++ b/shacl-shacl/shsh12-union.ttl
@@ -15,6 +15,6 @@ shsh:ShaclShaclUnion
         shsh:ShaclShaclProfiling ,
         shsh:ShaclShaclSparql ,
         shsh:ShaclShaclUserInterface ;
-    rdfs:label "SHACL for SHACL Union Validator"@en ;
+    rdfs:label "SHACL 1.2 Union SHACL-SHACL Validator"@en ;
     rdfs:comment "This shapes graph can be used to validate any SHACL 1.2 shapes graphs. It is the union of all specification-specific SHACL 1.2 shapes validators."@en ;
 .

--- a/shacl-shacl/shsh12-union.ttl
+++ b/shacl-shacl/shsh12-union.ttl
@@ -8,13 +8,13 @@ PREFIX shsh: <http://www.w3.org/ns/shacl-shacl#>
 shsh:ShaclShaclUnion
     a owl:Ontology ;
     prof:isProfileOf
-        sh:ShaclShaclCore ,
-        sh:ShaclShaclCompactSyntax ,
-        sh:ShaclShaclInferenceRules ,
-        sh:ShaclShaclNodeExpressions ,
-        sh:ShaclShaclProfiling ,
-        sh:ShaclShaclSparql ,
-        sh:ShaclShaclUserInterface ;
+        shsh:ShaclShaclCore ,
+        shsh:ShaclShaclCompactSyntax ,
+        shsh:ShaclShaclInferenceRules ,
+        shsh:ShaclShaclNodeExpressions ,
+        shsh:ShaclShaclProfiling ,
+        shsh:ShaclShaclSparql ,
+        shsh:ShaclShaclUserInterface ;
     rdfs:label "SHACL for SHACL Union Validator"@en ;
     rdfs:comment "This shapes graph can be used to validate any SHACL 1.2 shapes graphs. It is the union of all specification-specific SHACL 1.2 shapes validators."@en ;
 .


### PR DESCRIPTION
This PR does a few style-alignment tasks as a follow-on to [PR 2](https://github.com/w3c/shacl-resources/pull/2), and performs the first illustration of how `prof:isProfileOf` and `owl:imports` differ in implementation.  Note that the list of import statements of `shsh:ShaclShaclUnion` does not include `shsh:ShaclShaclCore`, because `shsh:ShaclShaclCore` will be transitively reached from `shsh:ShaclShaclNodeExpressions`.